### PR TITLE
fix: will include image and tag in update template's result

### DIFF
--- a/packages/etd-common/src/interfaces/db-interfaces/update_template_interfaces.ts
+++ b/packages/etd-common/src/interfaces/db-interfaces/update_template_interfaces.ts
@@ -19,6 +19,14 @@ export interface UpdateTemplateDBInterface extends Document {
 interface UpdateImageStack {
   imageName: string;
   tags: { tag: string };
+  /**
+   * Image's object id
+   */
+  image: string;
+  /**
+   * Image tag's id
+   */
+  tag: string;
 }
 
 interface UpdateContainerStack {

--- a/packages/etd-services/src/mongodb/db_service.ts
+++ b/packages/etd-services/src/mongodb/db_service.ts
@@ -85,7 +85,8 @@ export abstract class BaseMongoDBService<
    * @param data
    */
   async performPatch(data: T): Promise<T> {
-    return await this.model.findOneAndUpdate(
+    //@ts-ignore
+    return this.model.findOneAndUpdate(
       { _id: data._id },
       //@ts-ignore
       data,

--- a/packages/etd-services/src/mongodb/services/device/storage_management_item_service.ts
+++ b/packages/etd-services/src/mongodb/services/device/storage_management_item_service.ts
@@ -41,6 +41,7 @@ export class StorageManagementService extends BaseMongoDBService<schema.IStorage
    * @param deviceID
    */
   async auth(deviceID: string): Promise<boolean> {
+    //@ts-ignore
     return await this.model.exists({ qr_code: deviceID });
   }
 

--- a/packages/etd-services/src/mongodb/services/update-template/update_template_service.ts
+++ b/packages/etd-services/src/mongodb/services/update-template/update_template_service.ts
@@ -132,6 +132,30 @@ export class UpdateTemplateService extends BaseMongoDBService<schema.IUpdateTemp
       // @ts-ignore
       return await this.get(id);
     }
+
+    let returnedTemplate =
+      template[0] as interfaces.db.UpdateTemplateWithDockerImageDBInterface;
+
+    returnedTemplate.imageStacks = returnedTemplate.imageStacks.map((is) => ({
+      ...is,
+      tag: (is.tags as any)._id,
+      image: (is as any)._id,
+    }));
+
+    //@ts-ignore
+    returnedTemplate.containerStacks = returnedTemplate.containerStacks.map(
+      (cs) => ({
+        ...cs,
+        image: cs.image
+          ? {
+              ...cs.image,
+              image: (cs.image as any)._id,
+              tag: (cs.image.tags as any)._id,
+            }
+          : undefined,
+      })
+    );
+
     return template[0];
   }
 }

--- a/packages/etd-services/src/tests/mongodb/update/update.test.ts
+++ b/packages/etd-services/src/tests/mongodb/update/update.test.ts
@@ -62,9 +62,15 @@ describe("Given a update-script-script plugin", () => {
     expect(result.imageStacks[0].imageName).toStrictEqual(
       mockData.MockDockerImage.imageName
     );
+    expect(result.imageStacks[0].image).toBeDefined();
+    expect(result.imageStacks[0].tag).toBeDefined();
     expect(result.imageStacks[0].tags.tag).toStrictEqual(
       mockData.MockDockerImage.tags[0].tag
     );
+    expect(result.containerStacks[0].image.tag).toBeDefined();
+    expect(result.containerStacks[0].image.image).toBeDefined();
+    expect(result.containerStacks[0].image.imageName).toBeDefined();
+    expect(result.containerStacks[0].image.tags.tag).toBeDefined();
   });
 
   test("When calling getUpdateTemplateWithDockerImage if no image exists", async () => {


### PR DESCRIPTION
Currently update template will not include the image and tag's id in its result. This is different from the installation scripts's design and we want to provide the same experience as the installation template