### PR TITLE
fix: Update dependencies for main

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jest": "^27.5.1",
     "release-it": "^14.14.2",
     "typescript": "^4.6.3",
-    "@release-it/conventional-changelog": "^4.2.2",
+    "@release-it/conventional-changelog": "^4.3.0",
     "@release-it/bumper": "^3.0.1",
     "prettier": "^2.6.2",
     "ts-jest": "^27.1.4"

--- a/packages/etd-common/package.json
+++ b/packages/etd-common/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@etherdata-blockchain/logger": "^3.1.0",
+    "@etherdata-blockchain/logger": "^3.2.0",
     "@types/glob": "^7.2.0",
     "@types/jest": "^27.4.1",
     "glob": "^8.0.1",

--- a/packages/etd-docker-plan/package.json
+++ b/packages/etd-docker-plan/package.json
@@ -12,8 +12,8 @@
     "url": "https://github.com/etherdata-blockchain/packages.git"
   },
   "dependencies": {
-    "@etherdata-blockchain/common": "^3.1.0",
-    "@etherdata-blockchain/logger": "^3.1.0",
+    "@etherdata-blockchain/common": "^3.2.0",
+    "@etherdata-blockchain/logger": "^3.2.0",
     "@types/cli-progress": "^3.9.2",
     "@types/dockerode": "^3.3.8",
     "@types/jest-when": "^3.5.0",

--- a/packages/etd-next-js-handlers/package.json
+++ b/packages/etd-next-js-handlers/package.json
@@ -5,8 +5,8 @@
   "types": "dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@etherdata-blockchain/common": "^3.1.0",
-    "@etherdata-blockchain/services": "^3.1.0",
+    "@etherdata-blockchain/common": "^3.2.0",
+    "@etherdata-blockchain/services": "^3.2.0",
     "http-method-enum": "^1.0.0",
     "http-status-codes": "^2.2.0",
     "next": "^12.1.5",
@@ -17,7 +17,7 @@
     "url": "https://github.com/etherdata-blockchain/packages.git"
   },
   "devDependencies": {
-    "@etherdata-blockchain/storage-model": "^3.1.0",
+    "@etherdata-blockchain/storage-model": "^3.2.0",
     "node-mocks-http": "^1.11.0"
   },
   "publishConfig": {

--- a/packages/etd-remote-action/package.json
+++ b/packages/etd-remote-action/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@etherdata-blockchain/etd-schema-generator": "^3.1.0",
+    "@etherdata-blockchain/etd-schema-generator": "^3.2.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
@@ -21,7 +21,7 @@
     "url": "https://github.com/etherdata-blockchain/packages.git"
   },
   "dependencies": {
-    "@etherdata-blockchain/logger": "^3.1.0",
+    "@etherdata-blockchain/logger": "^3.2.0",
     "@types/chalk": "^2.2.0",
     "@types/cli-progress": "^3.9.2",
     "@types/jest": "^27.4.1",

--- a/packages/etd-schema-generator/package.json
+++ b/packages/etd-schema-generator/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/etherdata-blockchain/packages.git"
   },
   "devDependencies": {
-    "@etherdata-blockchain/logger": "^3.1.0",
+    "@etherdata-blockchain/logger": "^3.2.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
     "ts-json-schema-generator": "^1.0.0",

--- a/packages/etd-services/package.json
+++ b/packages/etd-services/package.json
@@ -5,8 +5,8 @@
   "types": "dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@etherdata-blockchain/logger": "^3.1.0",
-    "@etherdata-blockchain/storage-model": "^3.1.0",
+    "@etherdata-blockchain/logger": "^3.2.0",
+    "@etherdata-blockchain/storage-model": "^3.2.0",
     "@types/jsonwebtoken": "^8.5.8",
     "axios": "^0.26.1",
     "jsonwebtoken": "^8.5.1",
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
-    "mongodb-memory-server": "^8.5.0",
+    "mongodb-memory-server": "^8.5.1",
     "socket.io-client": "^4.4.1",
     "ts-jest": "^27.1.4"
   },

--- a/packages/etd-storage-model/package.json
+++ b/packages/etd-storage-model/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@etherdata-blockchain/common": "^3.1.0",
+    "@etherdata-blockchain/common": "^3.2.0",
     "mongoose": "6.3.1",
     "typescript": "4.6.3",
     "web3-eth": "1.7.3"
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "jest": "^27.5.1",
-    "mongodb-memory-server": "^8.5.0",
+    "mongodb-memory-server": "^8.5.1",
     "ts-jest": "^27.1.4"
   },
   "publishConfig": {

--- a/packages/etd-string-replacer/package.json
+++ b/packages/etd-string-replacer/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@etherdata-blockchain/logger": "^3.1.0",
+    "@etherdata-blockchain/logger": "^3.2.0",
     "@types/glob": "^7.2.0",
     "@types/jest": "^27.4.1",
     "glob": "^8.0.1",

--- a/packages/etd-worker-checker/package.json
+++ b/packages/etd-worker-checker/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@etherdata-blockchain/logger": "^3.1.0",
+    "@etherdata-blockchain/logger": "^3.2.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",
     "cancelable-promise": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,7 +928,7 @@
     mock-fs "^4.14.0"
     semver "^7.3.5"
 
-"@release-it/conventional-changelog@^4.2.2":
+"@release-it/conventional-changelog@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@release-it/conventional-changelog/-/conventional-changelog-4.3.0.tgz#a7758d7169ae5cdf4db15778f47844aa80b3fc08"
   integrity sha512-SAdattAPXyxADh+cWbNqlk7OBWh/SskYCj0hAb5VPmm/wrIR1dQrlKpsUQ/7O0WGGe7uhvj4YB8kVTIZipcc9w==


### PR DESCRIPTION
## Update dependencies for main

For commit [4814c4cb656922edc714cbd5e6336dc4a81e8bf7]

| Package | Package Path | Current Version | New Version|
|:-------:|:------------:|:--------------:|:---------:|
| @release-it/conventional-changelog | package.json | ^4.2.2 | ^4.3.0 |
| @etherdata-blockchain/logger | packages/etd-common/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/common | packages/etd-docker-plan/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/logger | packages/etd-docker-plan/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/common | packages/etd-next-js-handlers/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/services | packages/etd-next-js-handlers/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/storage-model | packages/etd-next-js-handlers/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/logger | packages/etd-remote-action/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/etd-schema-generator | packages/etd-remote-action/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/logger | packages/etd-schema-generator/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/logger | packages/etd-services/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/storage-model | packages/etd-services/package.json | ^3.1.0 | ^3.2.0 |
| mongodb-memory-server | packages/etd-services/package.json | ^8.5.0 | ^8.5.1 |
| @etherdata-blockchain/common | packages/etd-storage-model/package.json | ^3.1.0 | ^3.2.0 |
| mongodb-memory-server | packages/etd-storage-model/package.json | ^8.5.0 | ^8.5.1 |
| @etherdata-blockchain/logger | packages/etd-string-replacer/package.json | ^3.1.0 | ^3.2.0 |
| @etherdata-blockchain/logger | packages/etd-worker-checker/package.json | ^3.1.0 | ^3.2.0 |

### Suggested updates
**package.json** 
```json
{
  "name": "root",
  "private": true,
  "version": "3.3.0",
  "workspaces": [
    "packages/*"
  ],
  "devDependencies": {
    "@types/jest": "27.4.1",
    "@typescript-eslint/eslint-plugin": "^5.20.0",
    "@typescript-eslint/parser": "^5.20.0",
    "eslint": "^8.13.0",
    "eslint-config-airbnb-base": "^15.0.0",
    "eslint-plugin-import": "^2.26.0",
    "turbo": "^1.2.5",
    "jest": "^27.5.1",
    "release-it": "^14.14.2",
    "typescript": "^4.6.3",
    "@release-it/conventional-changelog": "^4.3.0",
    "@release-it/bumper": "^3.0.1",
    "prettier": "^2.6.2",
    "ts-jest": "^27.1.4"
  },
  "scripts": {
    "build": "turbo run build",
    "test": "jest",
    "coverage": "jest --coverage --forceExit",
    "release": "release-it --no-requireCleanWorkingDir",
    "release-dry": "release-it --no-requireCleanWorkingDir --dry-run"
  }
}
```
**packages/etd-common/package.json** 
```json
{
  "name": "@etherdata-blockchain/common",
  "version": "3.3.0",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "dependencies": {
    "@types/dockerode": "^3.3.8",
    "@types/json-schema": "^7.0.11",
    "bson": "^4.6.3",
    "json-schema": "^0.4.0",
    "typescript": "^4.6.3",
    "web3": "^1.7.3",
    "yaml": "^2.0.1"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "publishConfig": {
    "access": "public"
  },
  "devDependencies": {
    "@etherdata-blockchain/logger": "^3.2.0",
    "@types/glob": "^7.2.0",
    "@types/jest": "^27.4.1",
    "glob": "^8.0.1",
    "jest": "^27.5.1",
    "ts-jest": "^27.1.4",
    "ts-json-schema-generator": "1.0.0",
    "ts-node": "^10.7.0"
  },
  "scripts": {
    "build": "tsc",
    "test": "jest",
    "prebuild": "ts-node src/main.ts"
  },
  "gitHead": "222c868ef7b50aa6a8fb216019733e971c213a89"
}
```
**packages/etd-docker-plan/package.json** 
```json
{
  "name": "@etherdata-blockchain/docker-plan",
  "version": "3.3.0",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "publishConfig": {
    "access": "public"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "dependencies": {
    "@etherdata-blockchain/common": "^3.2.0",
    "@etherdata-blockchain/logger": "^3.2.0",
    "@types/cli-progress": "^3.9.2",
    "@types/dockerode": "^3.3.8",
    "@types/jest-when": "^3.5.0",
    "cli-progress": "^3.10.0",
    "dockerode": "^3.3.1",
    "jest": "^27.5.1",
    "jest-when": "^3.5.1",
    "typescript": "^4.6.3",
    "yaml": "^2.0.1"
  },
  "devDependencies": {
    "@types/jest": "^27.4.1",
    "ts-jest": "^27.1.4",
    "ts-node": "^10.7.0"
  },
  "scripts": {
    "test": "jest --coverage",
    "prebuild": "rm -rf dist",
    "build": "tsc",
    "start": "ts-node src/main.ts"
  }
}
```
**packages/etd-next-js-handlers/package.json** 
```json
{
  "name": "@etherdata-blockchain/next-js-handlers",
  "version": "3.3.0",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "dependencies": {
    "@etherdata-blockchain/common": "^3.2.0",
    "@etherdata-blockchain/services": "^3.2.0",
    "http-method-enum": "^1.0.0",
    "http-status-codes": "^2.2.0",
    "next": "^12.1.5",
    "typescript": "^4.6.3"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "devDependencies": {
    "@etherdata-blockchain/storage-model": "^3.2.0",
    "node-mocks-http": "^1.11.0"
  },
  "publishConfig": {
    "access": "public"
  },
  "scripts": {
    "build": "tsc"
  },
  "gitHead": "222c868ef7b50aa6a8fb216019733e971c213a89"
}
```
**packages/etd-remote-action/package.json** 
```json
{
  "name": "@etherdata-blockchain/remote-action",
  "version": "3.3.0",
  "description": "Remote ssh config file",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "publishConfig": {
    "access": "public"
  },
  "devDependencies": {
    "@etherdata-blockchain/etd-schema-generator": "^3.2.0",
    "jest": "^27.5.1",
    "ts-jest": "^27.1.4",
    "ts-node": "^10.7.0",
    "ts-node-dev": "^1.1.8",
    "typescript": "^4.6.3"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "dependencies": {
    "@etherdata-blockchain/logger": "^3.2.0",
    "@types/chalk": "^2.2.0",
    "@types/cli-progress": "^3.9.2",
    "@types/jest": "^27.4.1",
    "@types/node": "^17.0.25",
    "@types/yaml": "^1.9.7",
    "cancelable-promise": "^4.3.0",
    "chalk": "^5.0.1",
    "cli-progress": "^3.10.0",
    "moment": "^2.29.3",
    "node-ssh": "12.0.4",
    "yaml": "^2.0.1"
  },
  "scripts": {
    "start": "ts-node src/main.ts",
    "prebuild": "ts-node src/generate.ts",
    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
    "test": "jest",
    "build": "tsc"
  }
}
```
**packages/etd-schema-generator/package.json** 
```json
{
  "name": "@etherdata-blockchain/etd-schema-generator",
  "version": "3.3.0",
  "description": "JSON schema generator for typescript interfaces",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "publishConfig": {
    "access": "public"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "devDependencies": {
    "@etherdata-blockchain/logger": "^3.2.0",
    "jest": "^27.5.1",
    "ts-jest": "^27.1.4",
    "ts-json-schema-generator": "^1.0.0",
    "ts-node": "^10.7.0",
    "ts-node-dev": "^1.1.8",
    "typescript": "^4.6.3"
  },
  "scripts": {
    "test": "jest",
    "build": "tsc"
  }
}
```
**packages/etd-services/package.json** 
```json
{
  "name": "@etherdata-blockchain/services",
  "version": "3.3.0",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "dependencies": {
    "@etherdata-blockchain/logger": "^3.2.0",
    "@etherdata-blockchain/storage-model": "^3.2.0",
    "@types/jsonwebtoken": "^8.5.8",
    "axios": "^0.26.1",
    "jsonwebtoken": "^8.5.1",
    "moment": "^2.29.3",
    "query-string": "^7.1.1",
    "socket.io": "^4.4.1",
    "typescript": "^4.6.3"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "scripts": {
    "build": "tsc",
    "test": "jest --passWithNoTests"
  },
  "publishConfig": {
    "access": "public"
  },
  "devDependencies": {
    "@types/jest": "^27.4.1",
    "jest": "^27.5.1",
    "mongodb-memory-server": "^8.5.1",
    "socket.io-client": "^4.4.1",
    "ts-jest": "^27.1.4"
  },
  "gitHead": "222c868ef7b50aa6a8fb216019733e971c213a89"
}
```
**packages/etd-storage-model/package.json** 
```json
{
  "name": "@etherdata-blockchain/storage-model",
  "version": "3.3.0",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "dependencies": {
    "@etherdata-blockchain/common": "^3.2.0",
    "mongoose": "6.3.1",
    "typescript": "4.6.3",
    "web3-eth": "1.7.3"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "devDependencies": {
    "jest": "^27.5.1",
    "mongodb-memory-server": "^8.5.1",
    "ts-jest": "^27.1.4"
  },
  "publishConfig": {
    "access": "public"
  },
  "scripts": {
    "test": "jest --passWithNoTests",
    "build": "tsc"
  },
  "gitHead": "222c868ef7b50aa6a8fb216019733e971c213a89"
}
```
**packages/etd-string-replacer/package.json** 
```json
{
  "name": "@etherdata-blockchain/string-replacer",
  "version": "3.3.0",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "dependencies": {
    "@types/dockerode": "^3.3.8",
    "@types/json-schema": "^7.0.11",
    "bson": "^4.6.3",
    "json-schema": "^0.4.0",
    "typescript": "^4.6.3",
    "web3": "^1.7.3",
    "yaml": "^2.0.1"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "publishConfig": {
    "access": "public"
  },
  "devDependencies": {
    "@etherdata-blockchain/logger": "^3.2.0",
    "@types/glob": "^7.2.0",
    "@types/jest": "^27.4.1",
    "glob": "^8.0.1",
    "jest": "^27.5.1",
    "ts-jest": "^27.1.4",
    "ts-json-schema-generator": "1.0.0",
    "ts-node": "^10.7.0"
  },
  "scripts": {
    "build": "tsc",
    "test": "jest"
  },
  "gitHead": "222c868ef7b50aa6a8fb216019733e971c213a89"
}
```
**packages/etd-worker-checker/package.json** 
```json
{
  "name": "@etherdata-blockchain/worker-checker",
  "version": "3.3.0",
  "description": "Remote ssh config file",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "license": "MIT",
  "publishConfig": {
    "access": "public"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/etherdata-blockchain/packages.git"
  },
  "devDependencies": {
    "jest": "^27.5.1",
    "ts-node": "^10.7.0",
    "ts-node-dev": "^1.1.8",
    "typescript": "^4.6.3"
  },
  "dependencies": {
    "@etherdata-blockchain/logger": "^3.2.0",
    "@types/jest": "^27.4.1",
    "@types/node": "^17.0.25",
    "cancelable-promise": "^4.3.0",
    "moment": "^2.29.3",
    "ts-jest": "^27.1.4",
    "web3": "^1.7.3"
  },
  "scripts": {
    "start": "ts-node lib/index.ts",
    "test": "jest",
    "build": "tsc"
  }
}
```
