### PR TITLE
fix: search items by qr code

### DIFF
--- a/packages/etd-services/src/mongodb/services/device/storage_management_item_service.ts
+++ b/packages/etd-services/src/mongodb/services/device/storage_management_item_service.ts
@@ -105,7 +105,6 @@ export class StorageManagementService extends BaseMongoDBService<schema.IStorage
           $or: [
             { "status.networkSettings.localIpAddress": key },
             { "status.networkSettings.remoteIpAddress": key },
-            { qr_code: { $regex: ".*" + key + ".*" } },
           ],
         },
       },
@@ -114,6 +113,11 @@ export class StorageManagementService extends BaseMongoDBService<schema.IStorage
     const query = this.model
       .aggregate(pipelines)
       .limit(configs.Configurations.numberPerPage);
-    return query.exec();
+
+    const query2 = this.model.find({ qr_code: { $regex: ".*" + key + ".*" } });
+
+    const [result1, result2] = await Promise.all([query.exec(), query2.exec()]);
+
+    return [...result1, ...result2];
   }
 }

--- a/packages/etd-services/src/tests/mongodb/storage/item.test.ts
+++ b/packages/etd-services/src/tests/mongodb/storage/item.test.ts
@@ -65,14 +65,17 @@ describe("Given a storage item", () => {
   test("When search device by id", async () => {
     await schema.StorageItemModel.create(mockData.MockStorageItem);
     await schema.StorageItemModel.create(mockData.MockStorageItem2);
+    await schema.StorageItemModel.create(mockData.MockStorageItem3);
     await schema.DeviceModel.create(mockData.MockDeviceStatus);
     await schema.DeviceModel.create(mockData.MockDeviceStatus2);
 
     const plugin = new StorageManagementService();
     const result = await plugin.search(mockData.MockStorageItem.qr_code);
+    const result2 = await plugin.search(mockData.MockStorageItem3.qr_code);
 
     expect(result[0].qr_code).toBe(mockData.MockStorageItem.qr_code);
     expect(result).toHaveLength(1);
+    expect(result2).toHaveLength(1);
   });
 
   test("When calling auth", async () => {
@@ -170,10 +173,15 @@ describe("Given a storage item", () => {
     const id3 = await schema.StorageItemModel.create(mockData.MockStorageItem3);
 
     const service = new StorageManagementService();
+
     await service.unregisterDevicesByUser(mockData.MockStorageUserId2);
     const result = await service.getDeviceIdsByUser(
       mockData.MockStorageUserId2
     );
     expect(result).toHaveLength(0);
+    const searchedResults = await service.search(
+      mockData.MockStorageItem.qr_code
+    );
+    expect(searchedResults).toHaveLength(1);
   });
 });


### PR DESCRIPTION
When device doesn't contain any status, the search function will return empty